### PR TITLE
Merge MSI changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ coherence/libcoherence.so
 interconnect/libinterconnect.so
 memory/libmemory.so
 simpleCache/libsimpleCache.so
+branchCPP/libbranchCPP.so
+build/

--- a/coherence/coher_internal.h
+++ b/coherence/coher_internal.h
@@ -10,9 +10,22 @@ typedef enum _coherence_states
 {
     UNDEF = 0, // As tree find returns NULL, we need an unused for NULL
     MODIFIED,
+    SHARED_STATE,
     INVALID,
-    INVALID_MODIFIED
+    SHARED_MODIFIED,  // Shared and awaiting excl. M access
+    INVALID_MODIFIED, // Inval and awaiting excl. M access
+    INVALID_SHARED    // Invalid and awaiting shared data
 } coherence_states;
+
+static const char* coherence_state_map[] = {
+    [UNDEF] = "UNDEFINED",
+    [MODIFIED] = "MODIFIED",
+    [SHARED_STATE] = "SHARED",
+    [INVALID] = "INVALID",
+    [SHARED_MODIFIED] = "SHARED_MODIFIED",
+    [INVALID_MODIFIED] = "INVALID_MODIFIED",
+    [INVALID_SHARED] = "INVALID_SHARED"
+};
 
 typedef enum _coherence_scheme
 {
@@ -28,6 +41,13 @@ cacheMI(uint8_t is_read, uint8_t* permAvail, coherence_states currentState,
         uint64_t addr, int procNum);
 coherence_states
 snoopMI(bus_req_type reqType, cache_action* ca, coherence_states currentState,
+        uint64_t addr, int procNum);
+
+coherence_states
+cacheMSI(uint8_t is_read, uint8_t* permAvail, coherence_states currentState,
+        uint64_t addr, int procNum);
+coherence_states
+snoopMSI(bus_req_type reqType, cache_action* ca, coherence_states currentState,
         uint64_t addr, int procNum);
 
 #endif

--- a/coherence/protocol.c
+++ b/coherence/protocol.c
@@ -1,23 +1,136 @@
 #include "coher_internal.h"
 
-void sendBusRd(uint64_t addr, int procNum)
+// Cache -> Directory
+void sendRead(uint64_t addr, int procNum)
 {
-    inter_sim->busReq(BUSRD, addr, procNum);
+    inter_sim->busReq(READSHARED, addr, procNum);
 }
 
-void sendBusWr(uint64_t addr, int procNum)
+void sendReadEx(uint64_t addr, int procNum)
 {
-    inter_sim->busReq(BUSWR, addr, procNum);
+    inter_sim->busReq(READEX, addr, procNum);
 }
 
+// Directory -> cache
 void sendData(uint64_t addr, int procNum)
 {
     inter_sim->busReq(DATA, addr, procNum);
 }
 
-void indicateShared(uint64_t addr, int procNum)
-{
-    inter_sim->busReq(SHARED, addr, procNum);
+// void indicateShared(uint64_t addr, int procNum)
+// {
+//     inter_sim->busReq(SHARED, addr, procNum);
+// }
+
+
+// Called when cache is hitting us, asking if it has permission
+// In lecture diagrams, corresponds to Pr... messages
+// procnum is me
+coherence_states
+cacheMSI(uint8_t is_read, uint8_t* permAvail, coherence_states currentState,
+        uint64_t addr, int procNum) {
+    switch (currentState)
+    {
+        // We have access and nothing changes
+        case MODIFIED:
+            *permAvail = 1;
+            return MODIFIED;
+        // Access persists if read, otherwise upgrade
+        case SHARED_STATE:
+            if (is_read) {
+                *permAvail = 1;
+                return SHARED_STATE;
+            } else {
+                *permAvail = 0;
+                sendReadEx(addr, procNum);
+                return SHARED_MODIFIED;
+            }
+        // Get the value we need
+        case INVALID:
+            *permAvail = 0;
+            if (is_read) {
+                sendRead(addr, procNum);
+                return INVALID_SHARED;
+            } else {
+                sendReadEx(addr, procNum);
+                return INVALID_MODIFIED;
+            }
+        // Stall cases
+        case SHARED_MODIFIED:
+            *permAvail = is_read;
+            return SHARED_MODIFIED;
+
+        case INVALID_MODIFIED:
+        case INVALID_SHARED:
+            *permAvail = 0;
+            return currentState;
+
+        default:
+            fprintf(stderr, "State %d not supported, found on %lx\n",
+                    currentState, addr);
+            break;
+    }
+}
+
+coherence_states
+snoopMSI(bus_req_type reqType, cache_action* ca, coherence_states currentState,
+        uint64_t addr, int procNum) {
+    *ca = NO_ACTION;
+    switch (currentState)
+    {
+        // Main states
+        case MODIFIED:
+            // indicateShared(addr, procNum); // Needed for E state
+            if (reqType == READEX) {
+                // fprintf(stderr, " - Am modified, snooped READEX\n");
+                sendData(addr, procNum); 
+                *ca = INVALIDATE;
+                return INVALID;
+            } else if (reqType == READSHARED) {
+                // fprintf(stderr, " - Am modified, snooped READSHARED\n");
+                sendData(addr, procNum); 
+                return SHARED_STATE;
+            }
+            return MODIFIED;
+
+        case SHARED_STATE:
+            if (reqType == READEX) {
+                sendData(addr, procNum); 
+                *ca = INVALIDATE;
+                return INVALID;
+            } 
+            // Not sure what SHARED req type means
+            if (reqType == DATA || reqType == SHARED) {
+                *ca = DATA_RECV;
+            }
+            return SHARED_STATE;
+
+        case INVALID:
+            return INVALID;
+
+        // Stall states; hopefully we've snooped the data we want
+        case SHARED_MODIFIED:
+        case INVALID_MODIFIED:
+            if (reqType == DATA || reqType == SHARED) { 
+                *ca = DATA_RECV;
+                return MODIFIED;
+            }
+            return currentState;
+
+        case INVALID_SHARED:
+            if (reqType == DATA || reqType == SHARED) {
+                *ca = DATA_RECV;
+                return SHARED_STATE;
+            }
+            return INVALID_SHARED;
+        
+        default:
+            fprintf(stderr, "State %d not supported, found on %lx\n",
+                    currentState, addr);
+            break;
+    }
+
+    return INVALID;
 }
 
 coherence_states
@@ -28,7 +141,7 @@ cacheMI(uint8_t is_read, uint8_t* permAvail, coherence_states currentState,
     {
         case INVALID:
             *permAvail = 0;
-            sendBusWr(addr, procNum);
+            sendReadEx(addr, procNum);
             return INVALID_MODIFIED;
         case MODIFIED:
             *permAvail = 1;
@@ -67,7 +180,6 @@ snoopMI(bus_req_type reqType, cache_action* ca, coherence_states currentState,
                 *ca = DATA_RECV;
                 return MODIFIED;
             }
-
             return INVALID_MODIFIED;
         default:
             fprintf(stderr, "State %d not supported, found on %lx\n",

--- a/common/interconnect.h
+++ b/common/interconnect.h
@@ -7,8 +7,8 @@ struct _memory;
 typedef enum _bus_req_type
 {
     NO_REQ,
-    BUSRD,
-    BUSWR,
+    READSHARED,
+    READEX,
     DATA,
     SHARED,
     MEMORY

--- a/ex_coher.config
+++ b/ex_coher.config
@@ -3,6 +3,6 @@ __cache -E 1 -b 4 -s 8
 // the name is "foo/*" and it takes three arguments
 __foo/* -a 1 */
 __branch -s 7 -b 2 -g 1
-__coherence -s 0
+__coherence -s 1
 __interconnect
 __memory


### PR DESCRIPTION
MSI protocol runs without error, as specified in `ex_coher.config`. Some differences:
- Tick count is off from reference: exactly 80 off with simple provided 2-op traces, and thousands off for Wireroute out of ~10s of thousands of total ticks
- Printed `busReq` and `permReq`s almost perfectly match `refCoherence` when running Wireroute on `simpleCache`, but 30% differences for `refCache` (did not investigate further)