### PR TITLE
Fixed major bug with sharing data

### DIFF
--- a/coherence/protocol.c
+++ b/coherence/protocol.c
@@ -99,6 +99,11 @@ snoopMSI(bus_req_type reqType, cache_action* ca, coherence_states currentState,
                 *ca = INVALIDATE;
                 return INVALID;
             } 
+
+            if (reqType == READSHARED) {
+                sendData(addr, procNum);
+                return SHARED_STATE;
+            }
             // Not sure what SHARED req type means
             if (reqType == DATA || reqType == SHARED) {
                 *ca = DATA_RECV;


### PR DESCRIPTION
Shared states used to never send data, forcing a requestor to make a memory access. This is pretty big considering our project centers around shared data sending